### PR TITLE
wcdx.ini

### DIFF
--- a/dist/wcdx/src/main.cpp
+++ b/dist/wcdx/src/main.cpp
@@ -1,4 +1,5 @@
 #include "platform.h"
+#include "wcdx_ini.h"
 
 HINSTANCE DllInstance;
 
@@ -8,8 +9,13 @@ BOOL WINAPI DllMain(HINSTANCE hInstDLL, DWORD fdwReason, [[maybe_unused]] LPVOID
     {
     case DLL_PROCESS_ATTACH:
         DllInstance = hInstDLL;
+        wcdx_ini_Load("wcdx.ini");
         break;
-    }
+
+    case DLL_PROCESS_DETACH:
+        wcdx_ini_Save("wcdx.ini");
+        break;
+   }
 
     return TRUE;
 }

--- a/dist/wcdx/src/wcdx.cpp
+++ b/dist/wcdx/src/wcdx.cpp
@@ -88,7 +88,7 @@ Wcdx::Wcdx(LPCWSTR title, WNDPROC windowProc, bool _fullScreen)
 
     WcdxColor defColor = { 0, 0, 0, 0xFF };
     std::fill_n(_palette, std::size(_palette), defColor);
-
+    _fullScreen = exposed_fullScreen;
     SetFullScreen(IsDebuggerPresent() ? false : _fullScreen);
 
 #if DEBUG_SCREENSHOTS
@@ -769,13 +769,13 @@ void Wcdx::OnSizing(DWORD windowEdge, RECT* dragRect)
         break;
 
     default:
-        adjustWidth = height > (3 * width) / 4;
+        adjustWidth = height > (exposed_AspectRatioY * width) / exposed_AspectRatioX;
         break;
     }
 
     if (adjustWidth)
     {
-        width = (4 * height) / 3;
+        width = (exposed_AspectRatioX * height) / exposed_AspectRatioY;
         auto delta = width - (client.right - client.left);
         switch (windowEdge)
         {
@@ -798,7 +798,7 @@ void Wcdx::OnSizing(DWORD windowEdge, RECT* dragRect)
     }
     else
     {
-        height = (3 * width) / 4;
+        height = (exposed_AspectRatioY * width) / exposed_AspectRatioX;
         auto delta = height - (client.bottom - client.top);
         switch (windowEdge)
         {
@@ -929,6 +929,7 @@ void Wcdx::SetFullScreen(bool enabled)
             SWP_FRAMECHANGED | SWP_NOCOPYBITS | SWP_SHOWWINDOW);
 
         _fullScreen = true;
+        exposed_fullScreen = _fullScreen;
     }
     else
     {
@@ -942,6 +943,7 @@ void Wcdx::SetFullScreen(bool enabled)
             SWP_FRAMECHANGED | SWP_NOCOPYBITS | SWP_SHOWWINDOW);
 
         _fullScreen = false;
+        exposed_fullScreen = _fullScreen;
     }
 
     ConfineCursor();
@@ -950,8 +952,8 @@ void Wcdx::SetFullScreen(bool enabled)
 
 RECT Wcdx::GetContentRect(RECT clientRect)
 {
-    auto width = (4 * clientRect.bottom) / 3;
-    auto height = (3 * clientRect.right) / 4;
+    auto width = (exposed_AspectRatioX * clientRect.bottom) / exposed_AspectRatioY;
+    auto height = (exposed_AspectRatioY * clientRect.right) / exposed_AspectRatioX;
     if (width < clientRect.right)
     {
         clientRect.left = (clientRect.right - width) / 2;

--- a/dist/wcdx/src/wcdx.h
+++ b/dist/wcdx/src/wcdx.h
@@ -16,6 +16,10 @@
 
 #define DEBUG_SCREENSHOTS 0
 
+inline bool exposed_fullScreen = true;
+inline LONG exposed_AspectRatioX = 4;
+inline LONG exposed_AspectRatioY = 3;
+
 class Wcdx : public IWcdx
 {
 public:

--- a/dist/wcdx/src/wcdx_ini.h
+++ b/dist/wcdx/src/wcdx_ini.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "wcdx.h"
+    
+inline bool wcdx_ini_Save(const char* path) {
+    FILE* file = nullptr;
+    if (fopen_s(&file, path, "w") != 0 || !file) return false;
+    fprintf(file,
+        "; =============================================================================================\n"
+        "; wcdx settings\n"
+        "; =============================================================================================\n"
+        "; FullScreen: Start in fullscreen mode (1) or windowed mode (0)\n"
+        "FullScreen=%d\n"
+        "; AspectRatioX: Display aspect ratio X (4). WARNING! Changing this will cause image distortion.\n"
+        "AspectRatioX=%ld\n"
+        "; AspectRatioY: Display aspect ratio Y (3). WARNING! Changing this will cause image distortion.\n"
+        "AspectRatioY=%ld",
+        (int)exposed_fullScreen, exposed_AspectRatioX, exposed_AspectRatioY);
+    return fclose(file) == 0;
+}
+
+inline bool wcdx_ini_Load(const char* path) {
+    FILE* file = nullptr;
+    if (fopen_s(&file, path, "r") != 0 || !file)
+        return wcdx_ini_Save(path);
+
+    char line[256];
+    while (fgets(line, sizeof(line), file)) {
+        if (line[0] == ';' || line[0] == '#' || line[0] == '\n')
+            continue;
+        char* eq = strchr(line, '=');
+        if (!eq) continue;
+        *eq = '\0';
+        if (strcmp(line, "FullScreen") == 0)
+            exposed_fullScreen = atoi(eq + 1) != 0;
+        else if (strcmp(line, "AspectRatioX") == 0)
+            exposed_AspectRatioX = atol(eq + 1);
+        else if (strcmp(line, "AspectRatioY") == 0)
+            exposed_AspectRatioY = atol(eq + 1);
+    }
+    fclose(file);
+    return true;
+}


### PR DESCRIPTION
A simple .ini manager that allows window settings to be stored such as Fullscreen and optional aspect ratio.

A warning is included in the comments of wcdx.ini noting that changing the aspect ratio will distort the image.

I also went through and removed any std library dependencies.